### PR TITLE
merge PR: ci/add-missing-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         uses: google-github-actions/release-please-action@v3
         id: release
         with:
-          token: ${{ secrets.ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
           package-name: fetcher
           command: github-release


### PR DESCRIPTION
#1 introduced token misconfiguration as below.
```yaml
token: ${{ secrets.ACCESS_TOKEN }}
```

This ACCESS_TOKEN is currently unobtanium, hence needs adjustments.
